### PR TITLE
Fix triggering of path change

### DIFF
--- a/src/Transit.elm
+++ b/src/Transit.elm
@@ -148,12 +148,12 @@ tick tagger msg parent =
               tag ( { state | step = Exit, value = 1 - (time - state.start) / (fst state.durations) }, Cmd.none )
             else
               -- move to entering
-              tag ( { state | step = Enter, start = time, value = 0 }, Cmd.none )
+              tag ( { state | step = Enter, value = 0 }, Cmd.none )
 
           Enter ->
-            if time < state.start + (snd state.durations) then
+            if time < state.start + (fst state.durations) + (snd state.durations) then
               -- update value
-              tag ( { state | value = (time - state.start) / (snd state.durations) }, Cmd.none )
+              tag ( { state | value = (time - state.start - (fst state.durations)) / (snd state.durations) }, Cmd.none )
             else
               -- finished
               tag ( { state | step = Done, value = 1 }, Cmd.none )


### PR DESCRIPTION
Sometimes the runtime will delay a process longer than is requested sleep. In
this case, the transition may have already started the `Enter` phase, which
causes `start` to be reset. Becuase the `start` value is different from the
value expected by the delayed process, it fizzles.

This fix keeps the value in `start` constant and adjusts the animation math in
the `Enter` phase to account for `start` meaning the start of the animation
instead of the start of the phase.
