### PR TITLE
Ensure parentMsg is called

### DIFF
--- a/src/Transit.elm
+++ b/src/Transit.elm
@@ -155,7 +155,7 @@ tick tagger msg parent =
                     tag ( { state | step = Exit, start = time }, emitCmd )
 
             EmitMsg parentMsg time ->
-                if time == state.start then
+                if time >= state.start then
                     ( parent, Task.perform identity (Task.succeed parentMsg) )
                 else
                     ( parent, Cmd.none )


### PR DESCRIPTION
**Explanation:**
- Matching millisecond equality of`time` and `state.start` occasionally causes `EmitMsg` to issue no command because `Tick` doesn't always occur consistently.
- Change equality check to greater than or equal to for `time` and `state.start` to ensure the parent message is called.

[https://github.com/etaque/elm-transit/issues/5](https://github.com/etaque/elm-transit/issues/5)