### PR TITLE
Readme: Link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Delayed actions with transition progress for enter/exit animations in [Elm](http
 
 See also:
 
-* [elm-transit-style](http://package.elm-lang.org/packages/etaque/elm-transit-router/latest): animations for elm-html `style` attribute
+* [elm-transit-style](http://package.elm-lang.org/packages/etaque/elm-transit-style/latest): animations for elm-html `style` attribute
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Delayed actions with transition progress for enter/exit animations in [Elm](http
 
 See also:
 
-* [elm-transit-router](http://package.elm-lang.org/packages/etaque/elm-transit-router/latest): a drop-in router with animated route transitions
 * [elm-transit-style](http://package.elm-lang.org/packages/etaque/elm-transit-router/latest): animations for elm-html `style` attribute
 
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In your views, you can then either:
 
 * Use `getValue` to get the 1 -> 0 -> 1 varying Float, and `getStep` to know the current phase of transition.
 
-* Or use one of the provided functions in [elm-transit-style](http://package.elm-lang.org/packages/etaque/elm-transit-router/latest) (or create one of your own)
+* Or use one of the provided functions in [elm-transit-style](http://package.elm-lang.org/packages/etaque/elm-transit-style/latest) (or create one of your own)
 to add the visual effect in your view:
 
 ```elm

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See also:
 
 ## Usage
 
-(Full working example [here](./example/src))
+(Full working example [here](https://github.com/etaque/elm-transit/tree/master/example/src))
 
 Use `WithTransition` record extension to extend your own model:
 


### PR DESCRIPTION
* Fixes relative example link not working on http://package.elm-lang.org/packages/etaque/elm-transit/latest.
* Fixes elm-transit-style link
* Removed elm-transit-router link because the package is deprecated.